### PR TITLE
Relax constaint on containers. 0.4 is shipped with GHC7.0

### DIFF
--- a/regex-applicative.cabal
+++ b/regex-applicative.cabal
@@ -63,7 +63,8 @@ Library
   Exposed-modules:     Text.Regex.Applicative, Text.Regex.Applicative.Reference
   
   -- Packages needed in order to build this package.
-  Build-depends:       base == 4.3.*, containers == 0.3.*
+  Build-depends:       base == 4.3.*,
+                       containers >= 0.3 && < 0.5
   
   -- Modules not exported by this package.
   Other-modules:       Text.Regex.Applicative.Interface,


### PR DESCRIPTION
So cabal tries to pull 0.3 and breaks thing build with containers-0.4. 

I didn't updated version number
