### PR TITLE
Resolve #8: ListLike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.o
 *.hi
+
+dist/
+.cabal-sandbox
+cabal.sandbox.config
+.stack-work

--- a/Text/Regex/Applicative.hs
+++ b/Text/Regex/Applicative.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 --------------------------------------------------------------------
 -- |
 -- Module    : Text.Regex.Applicative
@@ -35,5 +36,162 @@ module Text.Regex.Applicative
     )
     where
 import Text.Regex.Applicative.Types
-import Text.Regex.Applicative.Interface
+import qualified Text.Regex.Applicative.Interface as I
 import Control.Applicative
+
+
+-- | 'RE' is a kind-of profunctor. This is its contravariant map.
+--
+-- (A dependency on the @profunctors@ package doesn't seem justified.)
+comap :: (s2 -> s1) -> RE [s1] s1 a -> RE [s2] s2 a
+comap f re =
+  case re of
+    Eps -> Eps
+    Symbol t p    -> Symbol t (p . f)
+    Alt r1 r2     -> Alt (comap f r1) (comap f r2)
+    App r1 r2     -> App (comap f r1) (comap f r2)
+    Fmap g r      -> Fmap g (comap f r)
+    Fail          -> Fail
+    Rep gr fn a r -> Rep gr fn a (comap f r)
+    Void r        -> Void (comap f r)
+
+-- | Match and return a single symbol which satisfies the predicate
+psym :: (s -> Bool) -> RE [s] s s
+psym = I.psym
+
+-- | Like 'psym', but allows to return a computed value instead of the
+-- original symbol
+msym :: (s -> Maybe a) -> RE l s a
+msym = I.msym
+
+-- | Match and return the given symbol
+sym :: Eq s => s -> RE [s] s s
+sym = I.sym
+
+-- | Match and return any single symbol
+anySym :: RE [s] s s
+anySym = I.anySym
+
+-- | Match and return the given sequence of symbols.
+--
+-- Note that there is an 'IsString' instance for regular expression, so
+-- if you enable the @OverloadedStrings@ language extension, you can write
+-- @string \"foo\"@ simply as @\"foo\"@.
+--
+-- Example:
+--
+-- >{-# LANGUAGE OverloadedStrings #-}
+-- >import Text.Regex.Applicative
+-- >
+-- >number = "one" *> pure 1  <|>  "two" *> pure 2
+-- >
+-- >main = print $ "two" =~ number
+string :: Eq a => [a] -> RE [s] a [a]
+string = I.string
+
+-- | Match zero or more instances of the given expression, which are combined using
+-- the given folding function.
+--
+-- 'Greediness' argument controls whether this regular expression should match
+-- as many as possible ('Greedy') or as few as possible ('NonGreedy') instances
+-- of the underlying expression.
+reFoldl :: Greediness -> (b -> a -> b) -> b -> RE [s] s a -> RE [s] s b
+reFoldl = I.reFoldl
+
+-- | Match zero or more instances of the given expression, but as
+-- few of them as possible (i.e. /non-greedily/). A greedy equivalent of 'few'
+-- is 'many'.
+--
+-- Examples:
+--
+-- >Text.Regex.Applicative> findFirstPrefix (few anySym  <* "b") "ababab"
+-- >Just ("a","abab")
+-- >Text.Regex.Applicative> findFirstPrefix (many anySym  <* "b") "ababab"
+-- >Just ("ababa","")
+few :: RE l s a -> RE l s [a]
+few = I.few
+
+
+-- | Return matched symbols as part of the return value
+withMatched :: RE [s] s a -> RE [s] s (a, [s])
+withMatched = I.withMatched
+
+-- | @s =~ a = match a s@
+(=~) :: [s] -> RE [s] s a -> Maybe a
+(=~) = (I.=~)
+infix 2 =~
+
+-- | Attempt to match a string of symbols against the regular expression.
+-- Note that the whole string (not just some part of it) should be matched.
+--
+-- Examples:
+--
+-- >Text.Regex.Applicative> match (sym 'a' <|> sym 'b') "a"
+-- >Just 'a'
+-- >Text.Regex.Applicative> match (sym 'a' <|> sym 'b') "ab"
+-- >Nothing
+--
+match :: RE [s] s a -> [s] -> Maybe a
+match = I.match
+
+-- | Find a string prefix which is matched by the regular expression.
+--
+-- Of all matching prefixes, pick one using left bias (prefer the left part of
+-- '<|>' to the right part) and greediness.
+--
+-- This is the match which a backtracking engine (such as Perl's one) would find
+-- first.
+--
+-- If match is found, the rest of the input is also returned.
+--
+-- Examples:
+--
+-- >Text.Regex.Applicative> findFirstPrefix ("a" <|> "ab") "abc"
+-- >Just ("a","bc")
+-- >Text.Regex.Applicative> findFirstPrefix ("ab" <|> "a") "abc"
+-- >Just ("ab","c")
+-- >Text.Regex.Applicative> findFirstPrefix "bc" "abc"
+-- >Nothing
+findFirstPrefix :: RE [s] s a -> [s] -> Maybe (a, [s])
+findFirstPrefix = I.findFirstPrefix
+
+-- | Find the longest string prefix which is matched by the regular expression.
+--
+-- Submatches are still determined using left bias and greediness, so this is
+-- different from POSIX semantics.
+--
+-- If match is found, the rest of the input is also returned.
+--
+-- Examples:
+--
+-- >Text.Regex.Applicative Data.Char> let keyword = "if"
+-- >Text.Regex.Applicative Data.Char> let identifier = many $ psym isAlpha
+-- >Text.Regex.Applicative Data.Char> let lexeme = (Left <$> keyword) <|> (Right <$> identifier)
+-- >Text.Regex.Applicative Data.Char> findLongestPrefix lexeme "if foo"
+-- >Just (Left "if"," foo")
+-- >Text.Regex.Applicative Data.Char> findLongestPrefix lexeme "iffoo"
+-- >Just (Right "iffoo","")
+findLongestPrefix :: RE [s] s a -> [s] -> Maybe (a, [s])
+findLongestPrefix = I.findLongestPrefix
+
+-- | Find the shortest prefix (analogous to 'findLongestPrefix')
+findShortestPrefix :: RE [s] s a -> [s] -> Maybe (a, [s])
+findShortestPrefix = I.findShortestPrefix
+
+-- | Find the leftmost substring that is matched by the regular expression.
+-- Otherwise behaves like 'findFirstPrefix'. Returns the result together with
+-- the prefix and suffix of the string surrounding the match.
+findFirstInfix :: RE [s] s a -> [s] -> Maybe ([s], a, [s])
+findFirstInfix = I.findFirstInfix
+
+-- | Find the leftmost substring that is matched by the regular expression.
+-- Otherwise behaves like 'findLongestPrefix'. Returns the result together with
+-- the prefix and suffix of the string surrounding the match.
+findLongestInfix :: RE [s] s a -> [s] -> Maybe ([s], a, [s])
+findLongestInfix = I.findLongestInfix
+
+-- | Find the leftmost substring that is matched by the regular expression.
+-- Otherwise behaves like 'findShortestPrefix'. Returns the result together with
+-- the prefix and suffix of the string surrounding the match.
+findShortestInfix :: RE [s] s a -> [s] -> Maybe ([s], a, [s])
+findShortestInfix = I.findShortestInfix

--- a/Text/Regex/Applicative.hs
+++ b/Text/Regex/Applicative.hs
@@ -43,7 +43,7 @@ import Control.Applicative
 -- | 'RE' is a kind-of profunctor. This is its contravariant map.
 --
 -- (A dependency on the @profunctors@ package doesn't seem justified.)
-comap :: (s2 -> s1) -> RE [s1] s1 a -> RE [s2] s2 a
+comap :: (s2 -> s1) -> RE s1 a -> RE s2 a
 comap f re =
   case re of
     Eps -> Eps
@@ -56,20 +56,20 @@ comap f re =
     Void r        -> Void (comap f r)
 
 -- | Match and return a single symbol which satisfies the predicate
-psym :: (s -> Bool) -> RE [s] s s
+psym :: (s -> Bool) -> RE s s
 psym = I.psym
 
 -- | Like 'psym', but allows to return a computed value instead of the
 -- original symbol
-msym :: (s -> Maybe a) -> RE l s a
+msym :: (s -> Maybe a) -> RE s a
 msym = I.msym
 
 -- | Match and return the given symbol
-sym :: Eq s => s -> RE [s] s s
+sym :: Eq s => s -> RE s s
 sym = I.sym
 
 -- | Match and return any single symbol
-anySym :: RE [s] s s
+anySym :: RE s s
 anySym = I.anySym
 
 -- | Match and return the given sequence of symbols.
@@ -86,7 +86,7 @@ anySym = I.anySym
 -- >number = "one" *> pure 1  <|>  "two" *> pure 2
 -- >
 -- >main = print $ "two" =~ number
-string :: Eq a => [a] -> RE [s] a [a]
+string :: Eq a => [a] -> RE a [a]
 string = I.string
 
 -- | Match zero or more instances of the given expression, which are combined using
@@ -95,7 +95,7 @@ string = I.string
 -- 'Greediness' argument controls whether this regular expression should match
 -- as many as possible ('Greedy') or as few as possible ('NonGreedy') instances
 -- of the underlying expression.
-reFoldl :: Greediness -> (b -> a -> b) -> b -> RE [s] s a -> RE [s] s b
+reFoldl :: Greediness -> (b -> a -> b) -> b -> RE s a -> RE s b
 reFoldl = I.reFoldl
 
 -- | Match zero or more instances of the given expression, but as
@@ -108,16 +108,16 @@ reFoldl = I.reFoldl
 -- >Just ("a","abab")
 -- >Text.Regex.Applicative> findFirstPrefix (many anySym  <* "b") "ababab"
 -- >Just ("ababa","")
-few :: RE l s a -> RE l s [a]
+few :: RE s a -> RE s [a]
 few = I.few
 
 
 -- | Return matched symbols as part of the return value
-withMatched :: RE [s] s a -> RE [s] s (a, [s])
+withMatched :: RE s a -> RE s (a, [s])
 withMatched = I.withMatched
 
 -- | @s =~ a = match a s@
-(=~) :: [s] -> RE [s] s a -> Maybe a
+(=~) :: [s] -> RE s a -> Maybe a
 (=~) = (I.=~)
 infix 2 =~
 
@@ -131,7 +131,7 @@ infix 2 =~
 -- >Text.Regex.Applicative> match (sym 'a' <|> sym 'b') "ab"
 -- >Nothing
 --
-match :: RE [s] s a -> [s] -> Maybe a
+match :: RE s a -> [s] -> Maybe a
 match = I.match
 
 -- | Find a string prefix which is matched by the regular expression.
@@ -152,7 +152,7 @@ match = I.match
 -- >Just ("ab","c")
 -- >Text.Regex.Applicative> findFirstPrefix "bc" "abc"
 -- >Nothing
-findFirstPrefix :: RE [s] s a -> [s] -> Maybe (a, [s])
+findFirstPrefix :: RE s a -> [s] -> Maybe (a, [s])
 findFirstPrefix = I.findFirstPrefix
 
 -- | Find the longest string prefix which is matched by the regular expression.
@@ -171,27 +171,27 @@ findFirstPrefix = I.findFirstPrefix
 -- >Just (Left "if"," foo")
 -- >Text.Regex.Applicative Data.Char> findLongestPrefix lexeme "iffoo"
 -- >Just (Right "iffoo","")
-findLongestPrefix :: RE [s] s a -> [s] -> Maybe (a, [s])
+findLongestPrefix :: RE s a -> [s] -> Maybe (a, [s])
 findLongestPrefix = I.findLongestPrefix
 
 -- | Find the shortest prefix (analogous to 'findLongestPrefix')
-findShortestPrefix :: RE [s] s a -> [s] -> Maybe (a, [s])
+findShortestPrefix :: RE s a -> [s] -> Maybe (a, [s])
 findShortestPrefix = I.findShortestPrefix
 
 -- | Find the leftmost substring that is matched by the regular expression.
 -- Otherwise behaves like 'findFirstPrefix'. Returns the result together with
 -- the prefix and suffix of the string surrounding the match.
-findFirstInfix :: RE [s] s a -> [s] -> Maybe ([s], a, [s])
+findFirstInfix :: RE s a -> [s] -> Maybe ([s], a, [s])
 findFirstInfix = I.findFirstInfix
 
 -- | Find the leftmost substring that is matched by the regular expression.
 -- Otherwise behaves like 'findLongestPrefix'. Returns the result together with
 -- the prefix and suffix of the string surrounding the match.
-findLongestInfix :: RE [s] s a -> [s] -> Maybe ([s], a, [s])
+findLongestInfix :: RE s a -> [s] -> Maybe ([s], a, [s])
 findLongestInfix = I.findLongestInfix
 
 -- | Find the leftmost substring that is matched by the regular expression.
 -- Otherwise behaves like 'findShortestPrefix'. Returns the result together with
 -- the prefix and suffix of the string surrounding the match.
-findShortestInfix :: RE [s] s a -> [s] -> Maybe ([s], a, [s])
+findShortestInfix :: RE s a -> [s] -> Maybe ([s], a, [s])
 findShortestInfix = I.findShortestInfix

--- a/Text/Regex/Applicative/Common.hs
+++ b/Text/Regex/Applicative/Common.hs
@@ -17,16 +17,16 @@ import Text.Regex.Applicative.Types
 import Text.Regex.Applicative.Interface
 
 -- | Decimal digit, i.e. @\'0\'@..@\'9\'@
-digit :: Num a => RE l Char a
+digit :: Num a => GenRE l Char a
 digit = fromIntegral . digitToInt <$> psym isDigit
 
 -- | Hexadecimal digit
 -- i.e. @\'0\'@..@\'9\'@, @\'a\'@..@\'f\'@, @\'A\'@..@\'F\'@.
-hexDigit :: Num a => RE l Char a
+hexDigit :: Num a => GenRE l Char a
 hexDigit = fromIntegral . digitToInt <$> psym isHexDigit
 
 -- | Add optional sign
-signed :: Num a => RE l Char a -> RE l Char a
+signed :: Num a => GenRE l Char a -> GenRE l Char a
 signed p = sign <*> p
   where
     sign =  id     <$ sym '+'
@@ -34,9 +34,9 @@ signed p = sign <*> p
         <|> pure id
 
 -- | Parse decimal number without sign.
-decimal :: Num a => RE l Char a
+decimal :: Num a => GenRE l Char a
 decimal = foldl' (\d i -> d*10 + i) 0 <$> some digit
 
 -- | Parse decimal number without sign.
-hexadecimal :: Num a => RE l Char a
+hexadecimal :: Num a => GenRE l Char a
 hexadecimal = foldl' (\d i -> d*16 + i) 0 <$> some hexDigit

--- a/Text/Regex/Applicative/Common.hs
+++ b/Text/Regex/Applicative/Common.hs
@@ -12,20 +12,21 @@ module Text.Regex.Applicative.Common (
 
 import Data.Char
 import Data.List (foldl')
-import Text.Regex.Applicative
-
+import Control.Applicative
+import Text.Regex.Applicative.Types
+import Text.Regex.Applicative.Interface
 
 -- | Decimal digit, i.e. @\'0\'@..@\'9\'@
-digit :: Num a => RE Char a
+digit :: Num a => RE l Char a
 digit = fromIntegral . digitToInt <$> psym isDigit
 
 -- | Hexadecimal digit
 -- i.e. @\'0\'@..@\'9\'@, @\'a\'@..@\'f\'@, @\'A\'@..@\'F\'@.
-hexDigit :: Num a => RE Char a
+hexDigit :: Num a => RE l Char a
 hexDigit = fromIntegral . digitToInt <$> psym isHexDigit
 
 -- | Add optional sign
-signed :: Num a => RE Char a -> RE Char a
+signed :: Num a => RE l Char a -> RE l Char a
 signed p = sign <*> p
   where
     sign =  id     <$ sym '+'
@@ -33,9 +34,9 @@ signed p = sign <*> p
         <|> pure id
 
 -- | Parse decimal number without sign.
-decimal :: Num a => RE Char a
+decimal :: Num a => RE l Char a
 decimal = foldl' (\d i -> d*10 + i) 0 <$> some digit
 
 -- | Parse decimal number without sign.
-hexadecimal :: Num a => RE Char a
+hexadecimal :: Num a => RE l Char a
 hexadecimal = foldl' (\d i -> d*16 + i) 0 <$> some hexDigit

--- a/Text/Regex/Applicative/Compile.hs
+++ b/Text/Regex/Applicative/Compile.hs
@@ -8,7 +8,7 @@ import Control.Applicative
 import Data.Maybe
 import qualified Data.IntMap as IntMap
 
-compile :: RE s a -> (a -> [Thread s r]) -> [Thread s r]
+compile :: RE l s a -> (a -> [Thread s r]) -> [Thread s r]
 compile e k = compile2 e (SingleCont k)
 
 data Cont a = SingleCont !a | EmptyNonEmpty !a !a
@@ -41,7 +41,7 @@ nonEmptyCont k =
 --
 -- compile2 function takes two continuations: one when the match is empty and
 -- one when the match is non-empty. See the "Rep" case for the reason.
-compile2 :: RE s a -> Cont (a -> [Thread s r]) -> [Thread s r]
+compile2 :: RE l s a -> Cont (a -> [Thread s r]) -> [Thread s r]
 compile2 e =
     case e of
         Eps -> \k -> emptyCont k ()
@@ -86,12 +86,12 @@ data FSMState
 
 type FSMMap s = IntMap.IntMap (s -> Bool, [FSMState])
 
-mkNFA :: RE s a -> ([FSMState], (FSMMap s))
+mkNFA :: RE l s a -> ([FSMState], (FSMMap s))
 mkNFA e =
     flip runState IntMap.empty $
         go e [SAccept]
   where
-  go :: RE s a -> [FSMState] -> State (FSMMap s) [FSMState]
+  go :: RE l s a -> [FSMState] -> State (FSMMap s) [FSMState]
   go e k =
     case e of
         Eps -> return k
@@ -112,13 +112,13 @@ mkNFA e =
             go n cont >> return cont
         Void n -> go n k
 
-  findEntries :: RE s a -> [FSMState]
+  findEntries :: RE l s a -> [FSMState]
   findEntries e =
     -- A simple (although a bit inefficient) way to find all entry points is
     -- just to use 'go'
     evalState (go e []) IntMap.empty
 
-compile2_ :: RE s a -> Cont [Thread s r] -> [Thread s r]
+compile2_ :: RE l s a -> Cont [Thread s r] -> [Thread s r]
 compile2_ e =
     let (entries, fsmap) = mkNFA e
         mkThread _ k1 (STransition i@(ThreadId n)) =

--- a/Text/Regex/Applicative/Interface.hs
+++ b/Text/Regex/Applicative/Interface.hs
@@ -11,7 +11,7 @@ import Text.Regex.Applicative.Types
 import Text.Regex.Applicative.Object
 import Prelude hiding (foldl, null, head, tail)
 import Data.ListLike (FoldableLL, foldl, ListLike, null, head, tail, fromList)
---import Data.Text (Text)
+import Data.Text (Text)
 
 instance Functor (GenRE l s) where
     fmap f x = Fmap f x
@@ -147,6 +147,7 @@ match re = let obj = compile re in \str ->
     results $
     foldl (flip step) obj str
 {- SPECIALIZE match RE s a -> [s] -> Maybe a -}
+{- SPECIALIZE match TRE a -> Text -> Maybe a -}
 
 -- | Find a string prefix which is matched by the regular expression.
 --
@@ -185,6 +186,7 @@ findFirstPrefix re str = go (compile re) str Nothing
                         Nothing -> res
                         Just (s, ss) -> go (step s obj') ss res
 {-# SPECIALIZE findFirstPrefix :: RE s a -> [s] -> Maybe (a, [s]) #-}
+{-# SPECIALIZE findFirstPrefix :: TRE a -> Text -> Maybe (a, Text) #-}
 
 -- | Find the longest string prefix which is matched by the regular expression.
 --
@@ -213,6 +215,7 @@ findLongestPrefix re str = go (compile re) str Nothing
                 Nothing -> res
                 Just (s, ss) -> go (step s obj) ss res
 {-# SPECIALIZE findLongestPrefix :: RE s a -> [s] -> Maybe (a, [s]) #-}
+{-# SPECIALIZE findLongestPrefix :: TRE a -> Text -> Maybe (a, Text) #-}
 
 -- | Find the shortest prefix (analogous to 'findLongestPrefix')
 findShortestPrefix :: ListLike l s => GenRE l s a -> l -> Maybe (a, l)
@@ -227,6 +230,7 @@ findShortestPrefix re str = go (compile re) str
                     Nothing -> Nothing
                     Just (s, ss) -> go (step s obj) ss
 {-# SPECIALIZE findShortestPrefix :: RE s a -> [s] -> Maybe (a, [s]) #-}
+{-# SPECIALIZE findShortestPrefix :: TRE a -> Text -> Maybe (a, Text) #-}
 
 -- | Find the leftmost substring that is matched by the regular expression.
 -- Otherwise behaves like 'findFirstPrefix'. Returns the result together with
@@ -236,6 +240,7 @@ findFirstInfix re str =
     fmap (\((first, res), last) -> (fromList first, res, last)) $
     findFirstPrefix ((,) <$> few anySym <*> re) str
 {-# SPECIALIZE findFirstInfix :: RE s a -> [s] -> Maybe ([s], a, [s]) #-}
+{-# SPECIALIZE findFirstInfix :: TRE a -> Text -> Maybe (Text, a, Text) #-}
 
 -- Auxiliary function for findExtremeInfix
 prefixCounter :: ListLike l s => GenRE l s (Int, l)
@@ -338,6 +343,7 @@ findExtremalInfix newOrOld re str =
 findLongestInfix :: ListLike l s => GenRE l s a -> l -> Maybe (l, a, l)
 findLongestInfix = findExtremalInfix preferOver
 {-# SPECIALIZE findLongestInfix :: RE s a -> [s] -> Maybe ([s], a, [s]) #-}
+{-# SPECIALIZE findLongestInfix :: TRE a -> Text -> Maybe (Text, a, Text) #-}
 
 -- | Find the leftmost substring that is matched by the regular expression.
 -- Otherwise behaves like 'findShortestPrefix'. Returns the result together with
@@ -345,3 +351,4 @@ findLongestInfix = findExtremalInfix preferOver
 findShortestInfix :: ListLike l s => GenRE l s a -> l -> Maybe (l, a, l)
 findShortestInfix = findExtremalInfix $ flip preferOver
 {-# SPECIALIZE findShortestInfix :: RE s a -> [s] -> Maybe ([s], a, [s]) #-}
+{-# SPECIALIZE findShortestInfix :: TRE a -> Text -> Maybe (Text, a, Text) #-}

--- a/Text/Regex/Applicative/ListLike.hs
+++ b/Text/Regex/Applicative/ListLike.hs
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------
 -- |
--- Module    : Text.Regex.Applicative
+-- Module    : Text.Regex.Applicative.ListLike
 -- Copyright : (c) Roman Cheplyaka
 -- License   : MIT
 --
@@ -11,7 +11,8 @@
 -- <https://github.com/feuerbach/regex-applicative/wiki/Examples>
 --------------------------------------------------------------------
 module Text.Regex.Applicative.ListLike
-    ( RE
+    ( GenRE
+    , TRE
     , sym
     , psym
     , msym

--- a/Text/Regex/Applicative/ListLike.hs
+++ b/Text/Regex/Applicative/ListLike.hs
@@ -1,0 +1,38 @@
+--------------------------------------------------------------------
+-- |
+-- Module    : Text.Regex.Applicative
+-- Copyright : (c) Roman Cheplyaka
+-- License   : MIT
+--
+-- Maintainer: Roman Cheplyaka <roma@ro-che.info>
+-- Stability : experimental
+--
+-- To get started, see some examples on the wiki:
+-- <https://github.com/feuerbach/regex-applicative/wiki/Examples>
+--------------------------------------------------------------------
+module Text.Regex.Applicative.ListLike
+    ( RE
+    , sym
+    , psym
+    , msym
+    , anySym
+    , string
+    , reFoldl
+    , Greediness(..)
+    , few
+    , comap
+    , withMatched
+    , match
+    , (=~)
+    , findFirstPrefix
+    , findLongestPrefix
+    , findShortestPrefix
+    , findFirstInfix
+    , findLongestInfix
+    , findShortestInfix
+    , module Control.Applicative
+    )
+    where
+import Text.Regex.Applicative.Types
+import Text.Regex.Applicative.Interface
+import Control.Applicative

--- a/Text/Regex/Applicative/Object.hs
+++ b/Text/Regex/Applicative/Object.hs
@@ -109,16 +109,16 @@ addThread t (ReObject q) =
         Thread { threadId_ = ThreadId i } -> ReObject $ SQ.insertUnique i t q
 
 -- | Compile a regular expression into a regular expression object
-compile :: RE l s r -> ReObject s r
+compile :: GenRE l s r -> ReObject s r
 compile =
     fromThreads .
     flip Compile.compile (\x -> [Accept x]) .
     renumber
 
-renumber :: RE l s a -> RE l s a
+renumber :: GenRE l s a -> GenRE l s a
 renumber e = flip evalState (ThreadId 1) $ go e
   where
-    go :: RE l s a -> State ThreadId (RE l s a)
+    go :: GenRE l s a -> State ThreadId (GenRE l s a)
     go e =
         case e of
             Eps -> return Eps

--- a/Text/Regex/Applicative/Object.hs
+++ b/Text/Regex/Applicative/Object.hs
@@ -109,16 +109,16 @@ addThread t (ReObject q) =
         Thread { threadId_ = ThreadId i } -> ReObject $ SQ.insertUnique i t q
 
 -- | Compile a regular expression into a regular expression object
-compile :: RE s r -> ReObject s r
+compile :: RE l s r -> ReObject s r
 compile =
     fromThreads .
     flip Compile.compile (\x -> [Accept x]) .
     renumber
 
-renumber :: RE s a -> RE s a
+renumber :: RE l s a -> RE l s a
 renumber e = flip evalState (ThreadId 1) $ go e
   where
-    go :: RE s a -> State ThreadId (RE s a)
+    go :: RE l s a -> State ThreadId (RE l s a)
     go e =
         case e of
             Eps -> return Eps

--- a/Text/Regex/Applicative/Reference.hs
+++ b/Text/Regex/Applicative/Reference.hs
@@ -47,7 +47,7 @@ getChar = P $ \s ->
      then []
      else [(head s, tail s)]
 
-re2monad :: ListLike l s => RE l s a -> P l s a
+re2monad :: ListLike l s => GenRE l s a -> P l s a
 re2monad r =
     case r of
         Eps -> return $ error "eps"
@@ -76,5 +76,5 @@ runP m s = case filter (null . snd) $ unP m s of
 --
 -- However, this is not very efficient implementation and is supposed to be
 -- used for testing only.
-reference :: ListLike l s => RE l s a -> l -> Maybe a
+reference :: ListLike l s => GenRE l s a -> l -> Maybe a
 reference r s = runP (re2monad r) s

--- a/Text/Regex/Applicative/Reference.hs
+++ b/Text/Regex/Applicative/Reference.hs
@@ -14,39 +14,40 @@
 
 {-# LANGUAGE GADTs #-}
 module Text.Regex.Applicative.Reference (reference) where
-import Prelude hiding (getChar)
+import Prelude hiding (getChar, null, head, tail)
 import Text.Regex.Applicative.Types
 import Control.Applicative
 import Control.Monad
+import Data.ListLike (ListLike, null, head, tail)
 
 
 -- A simple parsing monad
-newtype P s a = P { unP :: [s] -> [(a, [s])] }
+newtype P l s a = P { unP :: l -> [(a, l)] }
 
-instance Monad (P s) where
+instance Monad (P l s) where
     return x = P $ \s -> [(x, s)]
     (P a) >>= k = P $ \s ->
         a s >>= \(x,s) -> unP (k x) s
 
-instance Functor (P s) where
+instance Functor (P l s) where
     fmap = liftM
 
-instance Applicative (P s) where
+instance Applicative (P l s) where
     (<*>) = ap
     pure = return
 
-instance Alternative (P s) where
+instance Alternative (P l s) where
     empty = P $ const []
     P a1 <|> P a2 = P $ \s ->
         a1 s ++ a2 s
 
-getChar :: P s s
+getChar :: ListLike l s => P l s s
 getChar = P $ \s ->
-    case s of
-        [] -> []
-        c:cs -> [(c,cs)]
+  if null s
+     then []
+     else [(head s, tail s)]
 
-re2monad :: RE s a -> P s a
+re2monad :: ListLike l s => RE l s a -> P l s a
 re2monad r =
     case r of
         Eps -> return $ error "eps"
@@ -66,7 +67,7 @@ re2monad r =
         Void a -> re2monad a >> return ()
         Fail -> empty
 
-runP :: P s a -> [s] -> Maybe a
+runP :: ListLike l s => P l s a -> l -> Maybe a
 runP m s = case filter (null . snd) $ unP m s of
     (r, _) : _ -> Just r
     _ -> Nothing
@@ -75,5 +76,5 @@ runP m s = case filter (null . snd) $ unP m s of
 --
 -- However, this is not very efficient implementation and is supposed to be
 -- used for testing only.
-reference :: RE s a -> [s] -> Maybe a
+reference :: ListLike l s => RE l s a -> l -> Maybe a
 reference r s = runP (re2monad r) s

--- a/Text/Regex/Applicative/Types.hs
+++ b/Text/Regex/Applicative/Types.hs
@@ -6,7 +6,7 @@ import Control.Applicative
 -- The above import is needed for haddock to properly generate links to
 -- Applicative methods. But it's not actually used in the code, hence
 -- -fno-warn-unused-imports.
-
+import Data.Text (Text)
 
 newtype ThreadId = ThreadId Int
 
@@ -55,17 +55,23 @@ data Greediness = Greedy | NonGreedy
 --
 -- * 'some' @ra@ matches concatenation of one or more strings matched by @ra@
 -- and returns the list of @ra@'s return values on those strings.
-data RE l s a where
-    Eps :: RE l s ()
-    Symbol :: ThreadId -> (s -> Maybe a) -> RE l s a
-    Alt :: RE l s a -> RE l s a -> RE l s a
-    App :: RE l s (a -> b) -> RE l s a -> RE l s b
-    Fmap :: (a -> b) -> RE l s a -> RE l s b
-    Fail :: RE l s a
+data GenRE l s a where
+    Eps :: GenRE l s ()
+    Symbol :: ThreadId -> (s -> Maybe a) -> GenRE l s a
+    Alt :: GenRE l s a -> GenRE l s a -> GenRE l s a
+    App :: GenRE l s (a -> b) -> GenRE l s a -> GenRE l s b
+    Fmap :: (a -> b) -> GenRE l s a -> GenRE l s b
+    Fail :: GenRE l s a
     Rep :: Greediness    -- repetition may be greedy or not
         -> (b -> a -> b) -- folding function (like in foldl)
         -> b             -- the value for zero matches, and also the initial value
                          -- for the folding function
-        -> RE l s a
-        -> RE l s b
-    Void :: RE l s a -> RE l s ()
+        -> GenRE l s a
+        -> GenRE l s b
+    Void :: GenRE l s a -> GenRE l s ()
+
+-- | Regular expressions specialised to lists.
+type RE s a = GenRE [s] s a
+
+-- | Regular expressions specialised to 'Text'.
+type TRE a = GenRE Text Char a

--- a/Text/Regex/Applicative/Types.hs
+++ b/Text/Regex/Applicative/Types.hs
@@ -55,17 +55,17 @@ data Greediness = Greedy | NonGreedy
 --
 -- * 'some' @ra@ matches concatenation of one or more strings matched by @ra@
 -- and returns the list of @ra@'s return values on those strings.
-data RE s a where
-    Eps :: RE s ()
-    Symbol :: ThreadId -> (s -> Maybe a) -> RE s a
-    Alt :: RE s a -> RE s a -> RE s a
-    App :: RE s (a -> b) -> RE s a -> RE s b
-    Fmap :: (a -> b) -> RE s a -> RE s b
-    Fail :: RE s a
+data RE l s a where
+    Eps :: RE l s ()
+    Symbol :: ThreadId -> (s -> Maybe a) -> RE l s a
+    Alt :: RE l s a -> RE l s a -> RE l s a
+    App :: RE l s (a -> b) -> RE l s a -> RE l s b
+    Fmap :: (a -> b) -> RE l s a -> RE l s b
+    Fail :: RE l s a
     Rep :: Greediness    -- repetition may be greedy or not
         -> (b -> a -> b) -- folding function (like in foldl)
         -> b             -- the value for zero matches, and also the initial value
                          -- for the folding function
-        -> RE s a
-        -> RE s b
-    Void :: RE s a -> RE s ()
+        -> RE l s a
+        -> RE l s b
+    Void :: RE l s a -> RE l s ()

--- a/Text/Regex/Applicative/Types.hs
+++ b/Text/Regex/Applicative/Types.hs
@@ -28,8 +28,8 @@ threadId _ = Nothing
 data Greediness = Greedy | NonGreedy
     deriving (Show, Read, Eq, Ord, Enum)
 
--- | Type of regular expressions that recognize symbols of type @s@ and
--- produce a result of type @a@.
+-- | Type of regular expressions that consumes container @l@, recognize symbols
+-- of type @s@ and produce a result of type @a@.
 --
 -- Regular expressions can be built using 'Functor', 'Applicative' and
 -- 'Alternative' instances in the following natural way:
@@ -70,7 +70,33 @@ data GenRE l s a where
         -> GenRE l s b
     Void :: GenRE l s a -> GenRE l s ()
 
--- | Regular expressions specialised to lists.
+-- | Type of regular expressions that recognize symbols of type @s@ and
+-- produce a result of type @a@.
+--
+-- Regular expressions can be built using 'Functor', 'Applicative' and
+-- 'Alternative' instances in the following natural way:
+--
+-- * @f@ '<$>' @ra@ matches iff @ra@ matches, and its return value is the result
+-- of applying @f@ to the return value of @ra@.
+--
+-- * 'pure' @x@ matches the empty string (i.e. it does not consume any symbols),
+-- and its return value is @x@
+--
+-- * @rf@ '<*>' @ra@ matches a string iff it is a concatenation of two
+-- strings: one matched by @rf@ and the other matched by @ra@. The return value
+-- is @f a@, where @f@ and @a@ are the return values of @rf@ and @ra@
+-- respectively.
+--
+-- * @ra@ '<|>' @rb@ matches a string which is accepted by either @ra@ or @rb@.
+-- It is left-biased, so if both can match, the result of @ra@ is used.
+--
+-- * 'empty' is a regular expression which does not match any string.
+--
+-- * 'many' @ra@ matches concatenation of zero or more strings matched by @ra@
+-- and returns the list of @ra@'s return values on those strings.
+--
+-- * 'some' @ra@ matches concatenation of one or more strings matched by @ra@
+-- and returns the list of @ra@'s return values on those strings.
 type RE s a = GenRE [s] s a
 
 -- | Regular expressions specialised to 'Text'.

--- a/regex-applicative.cabal
+++ b/regex-applicative.cabal
@@ -29,6 +29,7 @@ Library
                        Text.Regex.Applicative.Common
                        Text.Regex.Applicative.Reference
                        Text.Regex.Applicative.StateQueue
+                       Text.Regex.Applicative.ListLike
   Other-modules:       Text.Regex.Applicative.Interface
                        Text.Regex.Applicative.Types
                        Text.Regex.Applicative.Compile

--- a/regex-applicative.cabal
+++ b/regex-applicative.cabal
@@ -23,6 +23,7 @@ Library
   Build-depends:       base < 5,
                        containers,
                        transformers,
+                       text,
                        ListLike >=4.2
   Exposed-modules:     Text.Regex.Applicative
                        Text.Regex.Applicative.Object

--- a/regex-applicative.cabal
+++ b/regex-applicative.cabal
@@ -53,6 +53,8 @@ Test-Suite test-regex-applicative
                        containers,
                        transformers,
                        smallcheck >= 1.0,
+                       text,
+                       ListLike,
                        tasty,
                        tasty-smallcheck,
                        tasty-hunit,

--- a/regex-applicative.cabal
+++ b/regex-applicative.cabal
@@ -22,7 +22,8 @@ Library
   Default-language:    Haskell2010
   Build-depends:       base < 5,
                        containers,
-                       transformers
+                       transformers,
+                       ListLike >=4.2
   Exposed-modules:     Text.Regex.Applicative
                        Text.Regex.Applicative.Object
                        Text.Regex.Applicative.Common

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: lts-2.21

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -36,7 +36,7 @@ re1 =
         two = pure 2 <* sym 'a' <* sym 'a'
     in (,) <$> (one <|> two) <*> (two <|> one)
 
-re1LL :: GenRE l Char (Int, Int)
+re1LL :: LL.GenRE l Char (Int, Int)
 re1LL =
     let one = pure 1 <* LL.sym 'a'
         two = pure 2 <* LL.sym 'a' <* LL.sym 'a'

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -36,7 +36,7 @@ re1 =
         two = pure 2 <* sym 'a' <* sym 'a'
     in (,) <$> (one <|> two) <*> (two <|> one)
 
-re1LL :: RE l Char (Int, Int)
+re1LL :: GenRE l Char (Int, Int)
 re1LL =
     let one = pure 1 <* LL.sym 'a'
         two = pure 2 <* LL.sym 'a' <* LL.sym 'a'


### PR DESCRIPTION
- Rename `RE` to `GenRE`, adding `l` parameter (for stream type)
- Introduce `RE s a = GenRE [s] s a` and `TRE a = GenRE Text Char a` types
- `Text.Regex.Applicative` still uses `RE` type signatures
- new module `Text.Regex.Applicative.ListLike` with general type

There weren't need to add any annotation in tests, so the change is rather small api-wise. Hopefully `SPECIALIZE` pragmas help with any performance too (i.e. no change).