### PR TITLE
Add criterion suite with replace benchmark

### DIFF
--- a/Text/Regex/Applicative.hs
+++ b/Text/Regex/Applicative.hs
@@ -25,6 +25,7 @@ module Text.Regex.Applicative
     , withMatched
     , match
     , (=~)
+    , replace
     , findFirstPrefix
     , findLongestPrefix
     , findShortestPrefix

--- a/Text/Regex/Applicative/Interface.hs
+++ b/Text/Regex/Applicative/Interface.hs
@@ -328,3 +328,13 @@ findLongestInfix = findExtremalInfix preferOver
 -- the prefix and suffix of the string surrounding the match.
 findShortestInfix :: RE s a -> [s] -> Maybe ([s], a, [s])
 findShortestInfix = findExtremalInfix $ flip preferOver
+
+-- | Replace matches of the regular expression with its value.
+--
+-- >Text.Regex.Applicative > replace ("!" <$ sym 'f' <* some (sym 'o')) "quuxfoofooooofoobarfobar"
+-- >"quux!!!bar!bar"
+replace :: RE s [s] -> [s] -> [s]
+replace r = ($ []) . go
+  where go ys = case findLongestInfix r ys of
+                    Nothing                -> (ys ++)
+                    Just (before, m, rest) -> (before ++) . (m ++) . go rest

--- a/benchmark/benchmark.hs
+++ b/benchmark/benchmark.hs
@@ -2,9 +2,18 @@ import Text.Regex.Applicative
 import Data.List
 import Data.Traversable
 import Data.Maybe
+import Criterion.Main
 
+regex :: RE Char String
 regex = sequenceA (replicate 500 $ sym 'a' <|> pure 'b') <* sequenceA (replicate 500 $ sym 'a')
 
-main = do
-    l <- getLine
-    print $ isJust $ l =~ regex
+matchRegex :: String -> Maybe String
+matchRegex = match regex
+
+a1000 :: String
+a1000 = replicate 1000 'a'
+
+main :: IO ()
+main = defaultMain
+  [ bgroup "basic" [ bench "all a" $ whnf matchRegex a1000 ]
+  ]

--- a/regex-applicative.cabal
+++ b/regex-applicative.cabal
@@ -1,7 +1,7 @@
 Name:                regex-applicative
 Version:             0.3.2.1
 Synopsis:            Regex-based parsing with applicative interface
-Description:         
+Description:
     regex-applicative is a Haskell library for parsing using regular expressions.
     Parsers can be built using Applicative interface.
 Homepage:            https://github.com/feuerbach/regex-applicative
@@ -36,6 +36,17 @@ Library
                    -fno-warn-name-shadowing
                    -fno-warn-missing-signatures
                    -fno-warn-orphans
+
+Benchmark benchmark-regex-applicative
+  type:       exitcode-stdio-1.0
+  hs-source-dirs:
+    benchmark
+  main-is:
+    benchmark.hs
+  Default-language:    Haskell2010
+  Build-depends:       base < 5,
+                       criterion,
+                       regex-applicative
 
 Test-Suite test-regex-applicative
   type:       exitcode-stdio-1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-2.21
+resolver: lts-2.22

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -174,6 +174,20 @@ tests = testGroup "Tests"
                 (findShortestInfix "bc" "tabc")
                 (Just ("ta", "bc",""))
             ]
+        , testGroup "replace"
+            [ u "t1"
+                (replace ("x" <$ "a" <|> "y" <$ "ab") "tabc")
+                "tyc"
+            , u "t2"
+                (replace ("y" <$ "ab" <|> "x" <$ "a") "tabc")
+                "tyc"
+            , u "t3"
+                (replace ("x" <$ "bc") "tabc")
+                "tax"
+            , u "t4"
+                (replace ("y" <$ "a" <|> "x" <$ "ab") "tacabc")
+                "tycxc"
+            ]
         ]
     , stateQueueTests
     ]


### PR DESCRIPTION
Related to #5, `loop` implementation seems to be superior in this artificial microbenchmark. Yet the difference is enormous.

<img width="971" alt="screen shot 2015-08-10 at 13 22 53" src="https://cloud.githubusercontent.com/assets/51087/9169140/fc8e4fc4-3f62-11e5-8a69-055edc9ce709.png">
<img width="955" alt="screen shot 2015-08-10 at 13 22 59" src="https://cloud.githubusercontent.com/assets/51087/9169141/fc94bddc-3f62-11e5-9de1-363b1150bc0e.png">
