### PR TITLE
instance Filtrable (RE s)

### DIFF
--- a/Text/Regex/Applicative.hs
+++ b/Text/Regex/Applicative.hs
@@ -38,11 +38,13 @@ module Text.Regex.Applicative
     , findLongestPrefixWithUncons
     , findShortestPrefixWithUncons
     , module Control.Applicative
+    , module Data.Filtrable
     )
     where
 import Text.Regex.Applicative.Types
 import Text.Regex.Applicative.Interface
 import Control.Applicative
+import Data.Filtrable
 
 {- $uncons
 The following functions take an argument that splits the input into the first symbol and

--- a/Text/Regex/Applicative/Interface.hs
+++ b/Text/Regex/Applicative/Interface.hs
@@ -19,6 +19,7 @@ comap f re =
     Alt r1 r2     -> Alt (comap f r1) (comap f r2)
     App r1 r2     -> App (comap f r1) (comap f r2)
     Fmap g r      -> Fmap g (comap f r)
+    CatMaybes r   -> CatMaybes (comap f r)
     Fail          -> Fail
     Rep gr fn a r -> Rep gr fn a (comap f r)
     Void r        -> Void (comap f r)
@@ -60,6 +61,8 @@ withMatched (App a b) =
         withMatched b
 withMatched Fail = Fail
 withMatched (Fmap f x) = (f *** id) <$> withMatched x
+withMatched (CatMaybes x) = CatMaybes $
+    (\ (as, s) -> flip (,) s <$> as) <$> withMatched x
 withMatched (Rep gr f a0 x) =
     Rep gr (\(a, s) (x, t) -> (f a x, s ++ t)) (a0, []) (withMatched x)
 -- N.B.: this ruins the Void optimization

--- a/Text/Regex/Applicative/Object.hs
+++ b/Text/Regex/Applicative/Object.hs
@@ -115,19 +115,9 @@ compile =
     renumber
 
 renumber :: RE s a -> RE s a
-renumber e = flip evalState (ThreadId 1) $ go e
-  where
-    go :: RE s a -> State ThreadId (RE s a)
-    go e =
-        case e of
-            Eps -> return Eps
-            Symbol _ p -> Symbol <$> fresh <*> pure p
-            Alt a1 a2 -> Alt <$> go a1 <*> go a2
-            App a1 a2 -> App <$> go a1 <*> go a2
-            Fail -> return Fail
-            Fmap f a -> Fmap f <$> go a
-            Rep g f b a -> Rep g f b <$> go a
-            Void a -> Void <$> go a
+renumber =
+    flip evalState (ThreadId 1) .
+    traversePostorder (\ case Symbol _ p -> flip Symbol p <$> fresh; a -> pure a)
 
 fresh :: State ThreadId ThreadId
 fresh = do

--- a/Text/Regex/Applicative/Reference.hs
+++ b/Text/Regex/Applicative/Reference.hs
@@ -58,6 +58,7 @@ re2monad r =
         Alt a1 a2 -> re2monad a1 <|> re2monad a2
         App a1 a2 -> re2monad a1 <*> re2monad a2
         Fmap f a -> fmap f $ re2monad a
+        CatMaybes a -> maybe empty pure =<< re2monad a
         Rep g f b a -> rep b
             where
             am = re2monad a

--- a/regex-applicative.cabal
+++ b/regex-applicative.cabal
@@ -20,7 +20,9 @@ Source-repository head
 
 Library
   Default-language:    Haskell2010
+  Default-extensions:  LambdaCase
   Build-depends:       base < 5,
+                       filtrable >= 0.1.3,
                        containers,
                        transformers
   Exposed-modules:     Text.Regex.Applicative
@@ -32,6 +34,7 @@ Library
                        Text.Regex.Applicative.Types
                        Text.Regex.Applicative.Compile
   GHC-Options:     -Wall
+                   -Werror=incomplete-patterns
                    -fno-warn-name-shadowing
 
 Test-Suite test-regex-applicative
@@ -46,6 +49,7 @@ Test-Suite test-regex-applicative
   Default-language:    Haskell2010
   Build-depends:       base < 5,
                        containers,
+                       filtrable >= 0.1.3,
                        transformers,
                        smallcheck >= 1.0,
                        tasty,

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -3,6 +3,7 @@ import Text.Regex.Applicative
 import Text.Regex.Applicative.Reference
 import Control.Applicative
 import Control.Monad
+import Data.Filtrable
 import Data.Traversable
 import Data.Maybe
 import Text.Printf
@@ -69,6 +70,8 @@ re8 = (,) <$> many (sym 'a' <|> sym 'b') <*> many (sym 'b' <|> sym 'c')
 re9 = many (sym 'a' <|> empty) <* sym 'b'
 re10 = few (sym 'a' <|> empty) <* sym 'b'
 
+re11 = (\ a b -> a <$ guard (a == b)) <$> anySym <*?> anySym
+
 prop re f s =
     let fs = map f s in
     reference re fs == (fs =~ re)
@@ -88,14 +91,15 @@ testRecognitionAgainstParsing re f s =
 
 tests = testGroup "Tests"
     [ testGroup "Engine tests"
-       [ t "re1" 10 $ prop re1 a
-       , t "re2" 10 $ prop re2 ab
-       , t "re3" 10 $ prop re3 ab
-       , t "re4" 10 $ prop re4 ab
-       , t "re5" 10 $ prop re5 a
-       , t "re6" 10 $ prop re6 a
-       , t "re7"  7 $ prop re7 abc
-       , t "re8"  7 $ prop re8 abc
+       [ t "re1" 10 $ prop re1  a
+       , t "re2" 10 $ prop re2  ab
+       , t "re3" 10 $ prop re3  ab
+       , t "re4" 10 $ prop re4  ab
+       , t "re5" 10 $ prop re5  a
+       , t "re6" 10 $ prop re6  a
+       , t "re7"  7 $ prop re7  abc
+       , t "re8"  7 $ prop re8  abc
+       , t "re11" 7 $ prop re11 abc
        ]
     , testGroup "Recognition vs parsing"
        [ t "re1" 10 $ testRecognitionAgainstParsing re1 a
@@ -108,6 +112,7 @@ tests = testGroup "Tests"
        , t "re8"  7 $ testRecognitionAgainstParsing re8 abc
        , t "re8" 10 $ testRecognitionAgainstParsing re9 ab
        , t "re8" 10 $ testRecognitionAgainstParsing re10 ab
+       , t "re11" 7 $ testRecognitionAgainstParsing re11 abc
        ]
     , testProperty "withMatched" prop_withMatched
     , testGroup "Tests for matching functions"


### PR DESCRIPTION
It turns out the implementation of regex matching is readily extended to include this feature. I find some patterns much easier to express with such functions. My motivating use case is matching valid Unicode scalar values and/or codepoints (in hexadecimal).
